### PR TITLE
Bugfix: Inventory consumes only items in selected slot.

### DIFF
--- a/bravo/inventory.py
+++ b/bravo/inventory.py
@@ -182,28 +182,30 @@ class Inventory(InventorySerializer):
 
         return False
 
-    def consume(self, item):
+    def consume(self, item, slot):
         """
         Attempt to remove a used holdable from the inventory.
 
         A return value of ``False`` indicates that there were no holdables of
-        the given type to consume.
+        the given type and slot to consume.
 
         :param tuple item: a key representing the type of the item
+        :param int slot: which slot was selected
         :returns: whether the item was successfully removed
         """
 
-        for i, t in enumerate(self.holdables):
-            if t is not None:
-                primary, secondary, count = t
+        try:
+            primary, secondary, count = self.holdables[slot]
+        except:
+            return False
 
-                if (primary, secondary) == item and count:
-                    count -= 1
-                    if count:
-                        self.holdables[i] = primary, secondary, count
-                    else:
-                        self.holdables[i] = None
-                    return True
+        if (primary, secondary) == item and count:
+            count -= 1
+            if count:
+                self.holdables[slot] = primary, secondary, count
+            else:
+                self.holdables[slot] = None
+            return True
 
         return False
 

--- a/bravo/plugins/build_hooks.py
+++ b/bravo/plugins/build_hooks.py
@@ -143,7 +143,7 @@ class Build(object):
             return True, builddata
 
         # Make sure we can remove it from the inventory first.
-        if not player.inventory.consume((block.slot, 0)):
+        if not player.inventory.consume((block.slot, 0), player.equipped):
             return True, builddata
 
         # Offset coords according to face.

--- a/bravo/plugins/physics.py
+++ b/bravo/plugins/physics.py
@@ -164,7 +164,8 @@ class Redstone(object):
             # Override the normal block placement, because it's so heavily
             # customized.
             print "Placing wire..."
-            if not player.inventory.consume((items["redstone"].slot, 0)):
+            if not player.inventory.consume((items["redstone"].slot, 0),
+                                            player.equiped):
                 return True, builddata
 
             self.tracked.add((factory, x, y, z))

--- a/bravo/tests/test_inventory.py
+++ b/bravo/tests/test_inventory.py
@@ -50,15 +50,27 @@ class TestEquipmentInternals(unittest.TestCase):
 
     def test_consume_holdable(self):
         self.i.holdables[0] = (2, 0, 1)
-        self.assertTrue(self.i.consume((2, 0)))
+        self.assertTrue(self.i.consume((2, 0), 0))
         self.assertEqual(self.i.holdables[0], None)
 
     def test_consume_holdable_empty(self):
-        self.assertFalse(self.i.consume((2, 0)))
+        self.assertFalse(self.i.consume((2, 0), 0))
 
     def test_consume_holdable_second_slot(self):
         self.i.holdables[1] = (2, 0, 1)
-        self.assertTrue(self.i.consume((2, 0)))
+        self.assertTrue(self.i.consume((2, 0), 1))
+        self.assertEqual(self.i.holdables[1], None)
+
+    def test_consume_holdable_multiple_stacks(self):
+        self.i.holdables[0] = (2, 0, 1)
+        self.i.holdables[1] = (2, 0, 1)
+        # consume second stack
+        self.assertTrue(self.i.consume((2, 0), 1))
+        self.assertEqual(self.i.holdables[0], (2, 0, 1))
+        self.assertEqual(self.i.holdables[1], None)
+        # consume second stack a second time
+        self.assertFalse(self.i.consume((2, 0), 1))
+        self.assertEqual(self.i.holdables[0], (2, 0, 1))
         self.assertEqual(self.i.holdables[1], None)
 
     def test_select_stack(self):


### PR DESCRIPTION
Previous version was looping through all entries looking for a fitting block - this is not the expected behavior of the client - instead only the selected slot should be consumed nothing else.

If you need for some reason the old behavior than we have to use either another method or the kwargs slot=None and either loop or use the given slot - but I couldn't really think about a situation where the loop should be needed.
