### PR TITLE
Correct underground for tracks

### DIFF
--- a/bravo/plugins/tracks.py
+++ b/bravo/plugins/tracks.py
@@ -14,7 +14,8 @@ tracks_allowed_on = set([
     blocks["diamond"].slot,
     blocks["diamond-ore"].slot,
     blocks["dirt"].slot,
-    blocks["glass"].slot,
+    blocks["double-step"].slot,
+    blocks["glass"].slot,                # Bravo only -- not Notchy
     blocks["glowing-redstone-ore"].slot,
     blocks["gold"].slot,
     blocks["gold-ore"].slot,
@@ -22,20 +23,23 @@ tracks_allowed_on = set([
     blocks["gravel"].slot,
     blocks["iron"].slot,
     blocks["iron-ore"].slot,
+    blocks["jack-o-lantern"].slot,
     blocks["lapis-lazuli"].slot,
-    blocks["lapis-lazuli-ore"].slot,  # Bravo only -- not Notchy
-    blocks["lightstone"].slot,        # Bravo only -- not Notchy
-    blocks["log"].slot,               # Bravo only -- not Notchy
-    blocks["mossy-cobblestone"].slot, # what a waste!
+    blocks["lapis-lazuli-ore"].slot,
+    blocks["leaves"].slot,
+    blocks["lightstone"].slot,
+    blocks["log"].slot,
+    blocks["mossy-cobblestone"].slot,
     blocks["obsidian"].slot,
     blocks["redstone-ore"].slot,
     blocks["sand"].slot,
     blocks["sandstone"].slot,
     blocks["slow-sand"].slot,
-    blocks["soil"].slot,              # Bravo only -- not Notchy
+    blocks["snow-block"].slot,
+    blocks["sponge"].slot,
     blocks["stone"].slot,
     blocks["wood"].slot,
-    blocks["wool"].slot,              # Minecraft Mania compatibility
+    blocks["wool"].slot,
 ])
 
 # metadata

--- a/docs/differences.rst
+++ b/docs/differences.rst
@@ -47,8 +47,4 @@ Minecarts
 The following blocks may have minecart tracks placed on them in Bravo, but not
 in the Notchian server:
 
- * Lapis lazuli ore
- * Lightstone
- * Log
- * Soil
- * Wool
+ * Glass


### PR DESCRIPTION
I just manually checked building tracks, wooden doors and metal doors on all blocks on a local standard notchian server (plug-in free) with the following partly unexpected results:

Tracks and doors buildable on Notchian (besides the obvious ones):

```
    * Lapis lazuli ore
    * Lightstone
    * Log
    * Wool
    * Leaves (!)
    * Sponges (!)
    * Jack-o-laterns (!)
    * Double stone slap
    * Snow block
```

Tracks and doors _not_ buildable on Notchian:

```
    * Soil (0x3C / Farmland)
    * Glass
```

Testing Farmland and Glass on Bravo worked - but I personally would suggest _not_ allowing Farmland, as this block does not have the same height as a default block - tracks or doors seem to hover a bit over the block - which looks strange.

So allowing glass would be the only main difference after implementing this patch. But this already would be really nice ;)

XXX: again the suggestion to re-factor the list of allowed underground to bravo/blocks.py as I will need the exact same list again for both door types - and I wouldn't wonder if this is the same behavior for many other "item blocks" such as workbench, furnace, etc.
