### PR TITLE
Unpack nibbles optimization

### DIFF
--- a/bravo/tests/test_utilities.py
+++ b/bravo/tests/test_utilities.py
@@ -3,6 +3,7 @@
 import unittest
 
 from numpy import array
+from numpy.testing import assert_array_equal
 
 import bravo.utilities
 
@@ -22,8 +23,8 @@ class TestCoordHandling(unittest.TestCase):
 class TestBitTwiddling(unittest.TestCase):
 
     def test_unpack_nibbles(self):
-        self.assertEqual(bravo.utilities.unpack_nibbles(["a"]), [1, 6])
-        self.assertEqual(bravo.utilities.unpack_nibbles("nibbles"),
+        assert_array_equal(bravo.utilities.unpack_nibbles("a"), [1, 6])
+        assert_array_equal(bravo.utilities.unpack_nibbles("nibbles"),
             [14, 6, 9, 6, 2, 6, 2, 6, 12, 6, 5, 6, 3, 7])
 
     def test_pack_nibbles(self):

--- a/bravo/utilities.py
+++ b/bravo/utilities.py
@@ -7,6 +7,7 @@ from functools import wraps
 from itertools import izip, tee
 from time import time
 
+import numpy
 from numpy import uint8, cast
 
 # Coord handling.
@@ -44,13 +45,10 @@ def unpack_nibbles(l):
 
     :returns: list of nibbles
     """
-
-    retval = []
-    for i in l:
-        i = ord(i)
-        retval.append(i & 15)
-        retval.append(i >> 4)
-    return retval
+    data = numpy.fromstring(l, dtype=uint8)
+    lower = numpy.bitwise_and(data, 15)
+    upper = numpy.right_shift(data, 4)
+    return numpy.dstack((lower, upper))
 
 def pack_nibbles(a):
     """

--- a/bravo/utilities.py
+++ b/bravo/utilities.py
@@ -36,7 +36,7 @@ def unpack_nibbles(l):
     Nibbles are half-byte quantities. The nibbles unpacked by this function
     are returned as unsigned numeric values.
 
-    >>> unpack_nibbles(["a"])
+    >>> unpack_nibbles("a")
     [6, 1]
     >>> unpack_nibbles("nibbles")
     [6, 14, 6, 9, 6, 2, 6, 2, 6, 12, 6, 5, 7, 3]
@@ -48,7 +48,7 @@ def unpack_nibbles(l):
     data = numpy.fromstring(l, dtype=uint8)
     lower = numpy.bitwise_and(data, 15)
     upper = numpy.right_shift(data, 4)
-    return numpy.dstack((lower, upper))
+    return numpy.dstack((lower, upper)).flat
 
 def pack_nibbles(a):
     """


### PR DESCRIPTION
Hi,
first of all, thank you for your work. I'm interested in helping here, so I had a look at the code and played a bit with the server today. 

While playing around I noticed it uses quite a bit of CPU (at least on my pc), so I did a bit of profiling and it seems that unpack_nibbles in one case used 28% of the total processing time for filling up the cache when starting the server (it didn't change a lot when connecting with a client and waiting for all chunks to load). Using numpy I could reduce that significant, so in my tests it's now barely noticable. Other parts of the code stand out more. That's my first real encounter with numpy, so there probably is some space for further optimization.

I'm not sure if you can recreate this, I could provide profiling stats if you want. Please tell me if and how I can improve the description in case there are questions.

Regards,
Reiner
