### PR TITLE
Optimize skylight regeneration

### DIFF
--- a/bravo/chunk.py
+++ b/bravo/chunk.py
@@ -178,8 +178,14 @@ class Chunk(ChunkSerializer):
         lightmap = zeros((16, 16, 128), dtype=uint8)
 
         for x, z in product(xrange(16), repeat=2):
+            height = self.height_at(x, z)
+
+            # fill all air blocks with light
+            lightmap[x, z, height + 1:] = 15
+
+            # dim the light going through the remaining blocks
             light = 15
-            for y in range(127, -1, -1):
+            for y in range(height, -1, -1):
                 dim = blocks[self.blocks[x, z, y]].dim
                 light -= dim
                 if light <= 0:


### PR DESCRIPTION
With the information in the heightmap I think one can safely assume that all blocks above the highest block in a chunk column are air. Air doesn't dim light, so for those blocks the lightmap can be generated quickly. Then, from the highest block, the algorithm continues as it was before.

In my tests this cuts down on a lot of loops, as the maps, that the default configuration generates, typically leave around 60 or more blocks free on the top. For a single chunk, this could mean 16 \* 16 \* 60 less loop iterations. In my profiling this was especially noticeable, as the block lookup for the dim value seems rather expensive. I was able to reduce the time spent on generating the lightmap to a tenth of what it was before in repeated tests.
