### PR TITLE
Simplify beaches code

### DIFF
--- a/bravo/plugins/generators.py
+++ b/bravo/plugins/generators.py
@@ -228,7 +228,7 @@ class BeachGenerator(object):
         for x, z in product(xrange(16), repeat=2):
             y = chunk.heightmap[x, z]
 
-            while y >= 60 and chunk.get_block((x, y, z)) in self.above:
+            while y > 60 and chunk.get_block((x, y, z)) in self.above:
                 y -= 1
 
             if not 60 < y < 66:

--- a/bravo/plugins/generators.py
+++ b/bravo/plugins/generators.py
@@ -228,14 +228,13 @@ class BeachGenerator(object):
         for x, z in product(xrange(16), repeat=2):
             y = chunk.heightmap[x, z]
 
-            while y and chunk.get_block((x, y, z)) in self.above:
+            while y >= 60 and chunk.get_block((x, y, z)) in self.above:
                 y -= 1
 
             if not 60 < y < 66:
                 continue
 
-            if (chunk.get_block((x, y + 1, z)) in self.above and
-                (chunk.get_block((x, y, z)) in self.replace)):
+            if chunk.get_block((x, y, z)) in self.replace:
                 chunk.blocks[x, z, y] = blocks["sand"].slot
 
     name = "beaches"


### PR DESCRIPTION
Early exit from the while loop once we've reached the lower bound. Drop the lookup for the block above, this has to be true. The loop exists at the first block that doesn't meet this condition, but its predecessor did.
