### PR TITLE
Broadcast item destruction to all other players

### DIFF
--- a/bravo/protocols/beta.py
+++ b/bravo/protocols/beta.py
@@ -474,7 +474,7 @@ class BravoProtocol(BetaServerProtocol):
                 self.transport.write(packet)
 
                 packet = make_packet("destroy", eid=entity.eid)
-                self.transport.write(packet)
+                self.factory.broadcast(packet)
 
                 self.factory.destroy_entity(entity)
 


### PR DESCRIPTION
When a player picked up an item, the packet to destroy it was send to
this client only. Therefore every other player still saw the item, but
was unable to pick it up as it was destroyed on the server.
