### PR TITLE
Broadcast entity destruction

### DIFF
--- a/bravo/protocols/beta.py
+++ b/bravo/protocols/beta.py
@@ -877,6 +877,8 @@ class BravoProtocol(BetaServerProtocol):
         if self.player:
             self.factory.world.save_player(self.username, self.player)
             self.factory.destroy_entity(self.player)
+            packet = make_packet("destroy", eid=self.player.eid)
+            self.factory.broadcast(packet)
 
         if self.username in self.factory.protocols:
             del self.factory.protocols[self.username]

--- a/bravo/protocols/beta.py
+++ b/bravo/protocols/beta.py
@@ -474,7 +474,7 @@ class BravoProtocol(BetaServerProtocol):
                 self.transport.write(packet)
 
                 packet = make_packet("destroy", eid=entity.eid)
-                self.transport.write(packet)
+                self.factory.broadcast(packet)
 
                 self.factory.destroy_entity(entity)
 


### PR DESCRIPTION
When a player picked up an item, the packet to destroy it was send to
this client only. Therefore every other player still saw the item, but
was unable to pick it up as it was destroyed on the server.

When a player quit the server, the entity wasn't destroyed on the other
clients. Fix this by broadcasting a destroy packet.
