### PR TITLE
Restore world time

### DIFF
--- a/bravo/factories/beta.py
+++ b/bravo/factories/beta.py
@@ -66,6 +66,7 @@ class BravoFactory(Factory):
 
         self.eid = 1
 
+        self.time = self.world.time
         self.time_loop = LoopingCall(self.update_time)
         self.time_loop.start(2)
 
@@ -291,6 +292,16 @@ class BravoFactory(Factory):
 
         packet = make_packet("create", eid=entity.eid)
         self.broadcast(packet)
+
+    def stopFactory(self):
+        """
+        Called before factory stops listening on ports. Used to perform
+        shutdown tasks.
+        """
+
+        # Write back current world time.
+        self.world.time = self.time
+        self.world.serializer.save_level(self.world)
 
     def pauseProducing(self):
         pass

--- a/bravo/plugins/serializers.py
+++ b/bravo/plugins/serializers.py
@@ -422,10 +422,7 @@ class Alpha(object):
             tag["Data"]["SpawnZ"].value)
 
         level.seed = tag["Data"]["RandomSeed"].value
-        if "Time" in tag["Data"]:
-            level.time = tag["Data"]["Time"].value
-        else:
-            level.time = 0
+        level.time = tag["Data"]["Time"].value
 
     def save_level(self, level):
         tag = self._save_level_to_tag(level)

--- a/bravo/plugins/serializers.py
+++ b/bravo/plugins/serializers.py
@@ -382,6 +382,7 @@ class Alpha(object):
         tag["Data"]["SpawnX"] = TAG_Int(level.spawn[0])
         tag["Data"]["SpawnY"] = TAG_Int(level.spawn[1])
         tag["Data"]["SpawnZ"] = TAG_Int(level.spawn[2])
+        tag["Data"]["Time"] = TAG_Long(level.time)
 
         return tag
 
@@ -421,6 +422,10 @@ class Alpha(object):
             tag["Data"]["SpawnZ"].value)
 
         level.seed = tag["Data"]["RandomSeed"].value
+        if "Time" in tag["Data"]:
+            level.time = tag["Data"]["Time"].value
+        else:
+            level.time = 0
 
     def save_level(self, level):
         tag = self._save_level_to_tag(level)

--- a/bravo/world.py
+++ b/bravo/world.py
@@ -93,6 +93,7 @@ class World(object):
 
         self.spawn = (0, 0, 0)
         self.seed = random.randint(0, sys.maxint)
+        self.time = 0
 
         self.serializer.load_level(self)
         self.serializer.save_level(self)


### PR DESCRIPTION
Load world time from disk on startup and write it back when the server shuts down.

I'm not happy with the check in `Alpha.load_level`, but it's necessary, otherwise the server will fail on any existing bravo world. Should this be handled differently? What's your thought on backwards-incompatible changes like this? Try to avoid them, or could we, for example, supply a convert tool that handles that and state that on the next release?
