### PR TITLE
Handle changes to player equipment

### DIFF
--- a/bravo/entity.py
+++ b/bravo/entity.py
@@ -80,6 +80,30 @@ class Player(Entity):
             item=item
         )
 
+    def save_equipment_to_packet(self):
+        """
+        Creates packets that include the equipment of the player. Equipment
+        is the item the player holds and all 4 armor parts.
+        """
+
+        packet = ""
+        slots = (self.inventory.holdables[0], self.inventory.armor[3],
+                 self.inventory.armor[2], self.inventory.armor[1],
+                 self.inventory.armor[0])
+
+        for slot, item in enumerate(slots):
+            if item is None:
+                continue
+
+            primary, secondary, count = item
+            packet += make_packet("entity-equipment",
+                eid=self.eid,
+                slot=slot,
+                primary=primary,
+                secondary=secondary
+            )
+        return packet
+
 class Pickup(Entity):
     """
     Class representing a dropped block or item.

--- a/bravo/protocols/beta.py
+++ b/bravo/protocols/beta.py
@@ -760,6 +760,32 @@ class BravoProtocol(BetaServerProtocol):
             packet = i.save_to_packet()
             self.transport.write(packet)
 
+            # Inform other players about changes to this player's equipment.
+            if container.wid == 0 and (container.slot in range(5, 9) or
+                                       container.slot == 36):
+
+                # Armor changes.
+                if container.slot in range(5, 9):
+                    item = i.armor[container.slot - 5]
+                    # Order of slots is reversed in the equipment package.
+                    slot = 4 - (container.slot - 5)
+                # Currently equipped item changes.
+                elif container.slot == 36:
+                    item = i.holdables[0]
+                    slot = 0
+
+                if item is None:
+                    primary, secondary = 65535, 0
+                else:
+                    primary, secondary, count = item
+                packet = make_packet("entity-equipment",
+                    eid=self.player.eid,
+                    slot=slot,
+                    primary=primary,
+                    secondary=secondary
+                )
+                self.factory.broadcast_for_others(packet, self)
+
         packet = make_packet("window-token", wid=0, token=container.token,
             acknowledged=selected)
         self.transport.write(packet)

--- a/bravo/protocols/beta.py
+++ b/bravo/protocols/beta.py
@@ -439,6 +439,8 @@ class BravoProtocol(BetaServerProtocol):
         for protocol in self.factory.protocols.itervalues():
             packet = protocol.player.save_to_packet()
             self.transport.write(packet)
+            packet = protocol.player.save_equipment_to_packet()
+            self.transport.write(packet)
             packet = make_packet("create", eid=protocol.player.eid)
             self.transport.write(packet)
 

--- a/bravo/tests/test_inventory.py
+++ b/bravo/tests/test_inventory.py
@@ -411,6 +411,43 @@ class TestInventoryIntegration(unittest.TestCase):
         self.assertEqual(self.i.crafting[0], None)
         self.assertEqual(self.i.crafted[0], None)
 
+    def test_armor_slots_take_one_item_only(self):
+        self.i.add((bravo.blocks.items["iron-boots"].slot, 0), 5)
+        self.i.select(36)
+        self.i.select(5)
+        self.assertEqual(self.i.armor[0], (bravo.blocks.items["iron-boots"].slot, 0, 1))
+        self.assertEqual(self.i.selected, (bravo.blocks.items["iron-boots"].slot, 0, 4))
+
+    def test_armor_slots_take_armor_items_only(self):
+        self.i.add((bravo.blocks.blocks["dirt"].slot, 0), 10)
+        self.i.select(36)
+        self.assertFalse(self.i.select(5))
+        self.assertEqual(self.i.armor[0], None)
+        self.assertEqual(self.i.selected, (bravo.blocks.blocks["dirt"].slot, 0, 10))
+
+    def test_pumpkin_as_helmet(self):
+        self.i.add((bravo.blocks.blocks["pumpkin"].slot, 0), 1)
+        self.i.select(36)
+        self.i.select(5)
+        self.assertEqual(self.i.armor[0], (bravo.blocks.blocks["pumpkin"].slot, 0, 1))
+        self.assertEqual(self.i.selected, None)
+
+    def test_armor_only_in_matching_slots(self):
+        for index, item in enumerate(["leather-helmet", "chainmail-chestplate",
+                                      "diamond-leggings", "gold-boots"]):
+            self.i.add((bravo.blocks.items[item].slot, 0), 1)
+            self.i.select(36)
+
+            # Can't be placed in other armor slots.
+            other_slots = list(range(4))
+            other_slots.remove(index)
+            for i in other_slots:
+                self.assertFalse(self.i.select(5 + i))
+
+            # But it can in the appropriate slot.
+            self.assertTrue(self.i.select(5 + index))
+            self.assertEqual(self.i.armor[index], (bravo.blocks.items[item].slot, 0, 1))
+
 class TestWorkbenchIntegration(unittest.TestCase):
     """
     select() numbers


### PR DESCRIPTION
Inform other players if a player changes his armor/currently holding item in the inventory, and send equipment when existing players are spawned for a joined player.

I have noted some bugs with armor handling, so I've added some tests that will fail right now. The bug `test_armor_slots_take_one_item_only` tests will probably vanish once the inventory knows about non-stackable blocks/items.
