### PR TITLE
chunk: Ignore higher blocks when spreading skylight.

### DIFF
--- a/bravo/chunk.py
+++ b/bravo/chunk.py
@@ -195,8 +195,15 @@ class Chunk(object):
         visited = set()
         glow = 14
 
+        max_height = 0
+        for x, z in product(xrange(16), xrange(16)):
+            max_height = max(max_height, self.heightmap[x, z])
+
         while glow:
             for coords in spread:
+                if coords[2] > max_height:
+                    continue
+
                 for dx, dz, dy in (
                     (1, 0, 0),
                     (-1, 0, 0),

--- a/bravo/chunk.py
+++ b/bravo/chunk.py
@@ -1,7 +1,7 @@
 from itertools import product
 
 from numpy import int8, uint8, uint32
-from numpy import cast, logical_not, transpose, where, zeros
+from numpy import cast, logical_not, transpose, where, zeros, amax
 
 from bravo.blocks import blocks, glowing_blocks
 from bravo.packets import make_packet
@@ -194,10 +194,7 @@ class Chunk(object):
             for coords in transpose(lightmap.nonzero()))
         visited = set()
         glow = 14
-
-        max_height = 0
-        for x, z in product(xrange(16), xrange(16)):
-            max_height = max(max_height, self.heightmap[x, z])
+        max_height = amax(self.heightmap)
 
         while glow:
             for coords in spread:


### PR DESCRIPTION
All air blocks above the heighest elevation in a chunk don't need to
spread their light. Only those besides the heighest block are relevant.
This can cut down on a lot of iterations when calculating light.
## 

This started as a minor optimization, but has great affect on flat landscapes. Imagine chunks that only consist of water at level 64. There is no need for all the air blocks above to spread their light, as they are full lit already.

Counting the iterations in the spreading loop yields these results (before/after):
    `test_boring_skylight_values` - 195072 - 0
    `test_skylight_spread` - 193896 - 3432
