### PR TITLE
chunk: Optimize heightmap update for a single column.

### DIFF
--- a/bravo/chunk.py
+++ b/bravo/chunk.py
@@ -366,15 +366,18 @@ class Chunk(object):
             if not self.populated:
                 return
 
-            # Regenerate heightmap at this coordinate. Honestly not sure
-            # whether or not this is cheaper than the set of conditional
-            # statements required to update it in relative terms instead of
-            # absolute terms. Revisit this later, maybe?
-            # XXX definitely re-examine this later!
-            for y in range(127, -1, -1):
-                if self.blocks[x, z, y]:
-                    break
-            self.heightmap[x, z] = y
+            # Regenerate heightmap at this coordinate.
+            if not block:
+                # If we replace the highest block with air, we need to go
+                # through all blocks below it to find the new top block.
+                height = self.heightmap[x, z]
+                if y == height:
+                    for y in range(height, -1, -1):
+                        if self.blocks[x, z, y]:
+                            break
+                    self.heightmap[x, z] = y
+            else:
+                self.heightmap[x, z] = max(self.heightmap[x, z], y)
 
             # Add to lightmap at this coordinate.
             if block in glowing_blocks:

--- a/bravo/tests/test_chunk.py
+++ b/bravo/tests/test_chunk.py
@@ -49,6 +49,29 @@ class TestChunkBlocks(unittest.TestCase):
         packet = chunk.get_damage_packet()
         self.assertEqual(packet, '\x35\x00\x00\x00\x02\x04\x00\x00\x00\x18\x01\x00')
 
+    def test_set_block_correct_heightmap(self):
+        """
+        Test heightmap update for a single column.
+        """
+
+        self.c.populated = True
+
+        self.assertEqual(self.c.heightmap[0, 0], 0)
+        self.c.set_block((0, 20, 0), 1)
+        self.assertEqual(self.c.heightmap[0, 0], 20)
+
+        self.c.set_block((0, 10, 0), 1)
+        self.assertEqual(self.c.heightmap[0, 0], 20)
+
+        self.c.set_block((0, 30, 0), 1)
+        self.assertEqual(self.c.heightmap[0, 0], 30)
+
+        self.c.destroy((0, 10, 0))
+        self.assertEqual(self.c.heightmap[0, 0], 30)
+
+        self.c.destroy((0, 30, 0))
+        self.assertEqual(self.c.heightmap[0, 0], 20)
+
 class TestNumpyQuirks(unittest.TestCase):
     """
     Tests for the bad interaction between several components of Bravo.


### PR DESCRIPTION
The loop is only necessary in case the highest block is replaced by air.
- If the highest block is replaced by air, look **below this block** for new top block.
- If a block is replaced by air that is not at the top, the heightmap is unaffected.
- If a block is set, compare it's height to the one in the heightmap.
