### PR TITLE
factories/beta: Flush dirty chunks on server shutdown.

### DIFF
--- a/bravo/factories/beta.py
+++ b/bravo/factories/beta.py
@@ -302,6 +302,10 @@ class BravoFactory(Factory):
         shutdown tasks.
         """
 
+        # Flush all dirty chunks to disk.
+        for chunk in self.world.dirty_chunk_cache.itervalues():
+            self.world.save_chunk(chunk)
+
         # Write back current world time.
         self.world.time = self.time
         self.world.serializer.save_level(self.world)


### PR DESCRIPTION
This one annoyed me too many times now. Quickly doing some tests in-game and restarting the server, just to find out he hasn't saved the chunk(s) yet.

By the way, is `World.saving` supposed to supress **all** writes to the world files? In that case, this has to be considered here. But I've found some other places where this check does not occur, so I would prefer to tackle those all at once in a separate commit.
