### PR TITLE
ibravo, protocols/beta: Added IUseHook interface.

### DIFF
--- a/bravo/ibravo.py
+++ b/bravo/ibravo.py
@@ -291,3 +291,25 @@ class ISignHook(ISortedPlugin):
         :param list text: list of lines of text
         :param bool new: whether this sign is newly placed
         """
+
+class IUseHook(IBravoPlugin):
+    """
+    Hook for actions to be taken when a player interacts with an entity.
+
+    Each plugin needs to specify a list of entity types it is interested in
+    in advance, and it will only be called for those.
+    """
+
+    def use_hook(factory, player, target, alternate):
+        """
+        Do things.
+
+        :param `Factory` factory: factory
+        :param `Player` player: player
+        :param `Entity` target: target of the interaction
+        :param bool alternate: whether the player right-clicked the target
+        """
+
+    targets = Attribute("""
+        List of entity names this plugin wants to be called for.
+        """)

--- a/bravo/protocols/beta.py
+++ b/bravo/protocols/beta.py
@@ -1,5 +1,5 @@
-from collections import namedtuple
-from itertools import product
+from collections import namedtuple, defaultdict
+from itertools import product, chain
 from time import time
 from urlparse import urlunparse
 from math import pi
@@ -17,11 +17,11 @@ from bravo.blocks import blocks, items
 from bravo.config import configuration
 from bravo.entity import Sign
 from bravo.factories.infini import InfiniClientFactory
-from bravo.ibravo import IChatCommand, IBuildHook, IDigHook, ISignHook
+from bravo.ibravo import IChatCommand, IBuildHook, IDigHook, ISignHook, IUseHook
 from bravo.inventory import Workbench, sync_inventories
 from bravo.location import Location
 from bravo.packets import parse_packets, make_packet, make_error_packet
-from bravo.plugin import retrieve_plugins, retrieve_sorted_plugins
+from bravo.plugin import retrieve_plugins, retrieve_sorted_plugins, retrieve_named_plugins
 from bravo.utilities import split_coords
 
 (STATE_UNAUTHENTICATED, STATE_CHALLENGED, STATE_AUTHENTICATED) = range(3)
@@ -70,6 +70,7 @@ class BetaServerProtocol(Protocol):
             1: self.login,
             2: self.handshake,
             3: self.chat,
+            7: self.use,
             10: self.grounded,
             11: self.position,
             12: self.orientation,
@@ -125,6 +126,11 @@ class BetaServerProtocol(Protocol):
     def chat(self, container):
         """
         Hook for chat packets.
+        """
+
+    def use(self, container):
+        """
+        Hook for use packets.
         """
 
     def grounded(self, container):
@@ -420,6 +426,13 @@ class BravoProtocol(BetaServerProtocol):
             [])
         self.sign_hooks = retrieve_sorted_plugins(ISignHook, names)
 
+        names = configuration.getlistdefault(self.config_name, "use_hooks",
+            [])
+        self.use_hooks = defaultdict(list)
+        for plugin in retrieve_named_plugins(IUseHook, names):
+            for target in plugin.targets:
+                self.use_hooks[target].append(plugin)
+
         self.last_dig_build_timer = time()
 
     def authenticated(self):
@@ -593,6 +606,20 @@ class BravoProtocol(BetaServerProtocol):
             # Send the message up to the factory to be chatified.
             message = "<%s> %s" % (self.username, container.message)
             self.factory.chat(message)
+
+    def use(self, container):
+        """
+        For each entity in proximity (4 blocks), check if it is the target
+        of this packet and call all hooks that stated interested in this
+        type.
+        """
+        nearby_players = self.factory.players_near(self.player, 4)
+        for entity in chain(self.entities_near(4), nearby_players):
+            if entity.eid == container.target:
+                for hook in self.use_hooks[entity.name]:
+                    hook.use_hook(self.factory, self.player, entity,
+                        container.button == 0)
+                break
 
     def digging(self, container):
         # XXX several improvements should happen here


### PR DESCRIPTION
Plugins that implement this interface will be called when a player
interacts with another entity.
## 

Sadly no tests. I'd really appreciate suggestions on this thought. Construction of the use_hooks dictionary could be made more generic, because I assume sooner or later other plugins will need to state which objects they are interested in, but I think it may be too early to settle on something now.

I have changed the name of the last parameter of `use_hook` to `alternate`. It used to be button before, but I thought this is consistent with inventory's `select`.

https://gist.github.com/905926 is a small example of a plugin implementing this interface. Left clicking on players sets them on fire, right-clicking will remove it. I reverted metadata in packets to a previous version, because for the sake of this test it was easier to pass metadata to make_packet. If you want to try it out, note that it needs `fix_players_near` applied.
