### PR TITLE
amp: Fix world factory detection in console factory.

### DIFF
--- a/bravo/amp.py
+++ b/bravo/amp.py
@@ -2,6 +2,7 @@ from twisted.internet.protocol import Factory
 from twisted.protocols.amp import AMP, Command, Unicode, ListOf
 
 from bravo import version as bravo_version
+from bravo.factories.beta import BravoFactory
 from bravo.ibravo import IConsoleCommand
 from bravo.plugin import retrieve_plugins
 
@@ -82,9 +83,15 @@ class ConsoleRPCFactory(Factory):
     protocol = ConsoleRPCProtocol
 
     def __init__(self, service):
-        self.factories = service.namedServices
+        self.services = service.namedServices
 
     def buildProtocol(self, addr):
-        protocol = self.protocol(self.factories)
+        factories = {}
+        for name, service in self.services.iteritems():
+            factory = service.args[1]
+            if isinstance(factory, BravoFactory):
+                factories[factory.name] = factory
+
+        protocol = self.protocol(factories)
         protocol.factory = self
         return protocol


### PR DESCRIPTION
I've seen you doing that (getting factory out of the server again) for the web interface, so I figured I might do that as well for the console.

Factories will be retrieved at a later point, because ConsoleRPCFactory is created before the configuration of other services. If order does not matter ( https://github.com/MostAwesomeDude/bravo/blob/master/bravo/service.py#L23 ), `configure_services` could be called before and building `self.factories` could go into `__init__` again. I don't know if this order is intentional.

I'd really like to make the console work again, at least a bit. It does break on unknown commands (you already said it does need lots of work), but right now it'll break when just trying to select a world. 
