### PR TITLE
Adding support for decoding wolves

### DIFF
--- a/bravo/packets/beta.py
+++ b/bravo/packets/beta.py
@@ -286,6 +286,7 @@ packets = {
             cow=92,
             chuck=93,
             squid=94,
+            wolf=95,
         ),
         SBInt32("x"),
         SBInt32("y"),


### PR DESCRIPTION
The mob decoding doesn't have wolves in the list of mobs, this causes wolf-spawn packets not to be decoded. I've added wolves to the dictionary. 
