### PR TITLE
Re-name TreeGenerator to SaplingGenerator (clarity)

### DIFF
--- a/bravo/plugins/generators.py
+++ b/bravo/plugins/generators.py
@@ -432,7 +432,7 @@ class CaveGenerator(object):
     before = ("grass", "erosion", "simplex", "complex", "boring")
     after = tuple()
 
-class TreeGenerator(object):
+class SaplingGenerator(object):
     """
     Plant saplings at relatively silly places around the map.
     """
@@ -485,7 +485,7 @@ class TreeGenerator(object):
                 if chunk.get_block((x, y, z)) in self.ground:
                     chunk.set_block((x, y + 1, z), blocks["sapling"].slot)
 
-    name = "trees"
+    name = "saplings"
 
     before = ("grass", "erosion", "simplex", "complex", "boring")
     after = tuple()
@@ -502,4 +502,4 @@ beaches = BeachGenerator()
 ore = OreGenerator()
 safety = SafetyGenerator()
 caves = CaveGenerator()
-trees = TreeGenerator()
+saplings = SaplingGenerator()

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -98,8 +98,8 @@ Simplex
 
 Generates organic-looking, continuously smooth terrain.
 
-Trees
------
+Saplings
+--------
 
 Plants saplings at relatively silly places around the map.
 


### PR DESCRIPTION
Re-name TreeGenerator to SaplingGenerator, since it's really placing saplings, not trees. Seems silly, but avoid confusion when possible.

Commit includes the documentation update to plugins.rst reflecting the new name, too. Figured it'd be best to clarify all of this before trees make their way into the bravo.ini.example.
