### PR TITLE
Fix update_season not working if days are skipped

### DIFF
--- a/bravo/factories/beta.py
+++ b/bravo/factories/beta.py
@@ -206,11 +206,21 @@ class BravoFactory(Factory):
         Update the world's season.
         """
 
+        # Get a sorted list of all the seasons
         plugins = configuration.getlistdefault(self.config_name,
             "seasons", [])
-        for plugin in retrieve_named_plugins(ISeason, plugins):
-            if plugin.day == self.day:
-                self.world.season = plugin
+        all_seasons = [p for p in retrieve_named_plugins(ISeason, plugins)]
+        all_seasons.sort(key=lambda s: s.day)
+
+        # Get all the seasons that we have past the start date of this year
+        past_seasons = [s for s in all_seasons if s.day <= self.day]
+        if past_seasons:
+            # The most recent one is the one we are in
+            self.world.season = past_seasons[-1]
+        else:
+            # We haven't past any seasons yet this year, so grab the last one
+            # from 'last year'
+            self.world.season = all_seasons[-1]
 
     def chat(self, message):
         """

--- a/bravo/tests/factories/test_beta.py
+++ b/bravo/tests/factories/test_beta.py
@@ -61,7 +61,7 @@ class TestBravoFactoryStarted(unittest.TestCase):
             "automatons"    : "",
             "generators"    : "",
             "port"          : "0",
-            "seasons"       : "",
+            "seasons"       : "winter, spring",
             "serializer"    : "alpha",
             "url"           : "file://%s" % self.d,
         }
@@ -138,3 +138,23 @@ class TestBravoFactoryStarted(unittest.TestCase):
         for player, radius, result in expected_results:
             found = [p.eid for p in self.f.players_near(player, radius)]
             self.assertEqual(set(found), set(result))
+
+    def test_update_season_simple(self):
+        self.f.day = 90
+        self.f.update_season()
+        self.assertEqual(self.f.world.season.name, "spring")
+
+        self.f.day = 0
+        self.f.update_season()
+        self.assertEqual(self.f.world.season.name, "winter")
+
+    def test_update_season_advanced(self):
+        self.f.day = 0
+        self.f.update_season()
+        self.assertEqual(self.f.world.season.name, "winter")
+
+        self.f.day = 92
+        self.f.update_season()
+        self.assertEqual(self.f.world.season.name, "spring")
+
+    test_update_season_advanced.todo = "update_seasons can't handle skipping the start day"

--- a/bravo/tests/factories/test_beta.py
+++ b/bravo/tests/factories/test_beta.py
@@ -156,5 +156,3 @@ class TestBravoFactoryStarted(unittest.TestCase):
         self.f.day = 92
         self.f.update_season()
         self.assertEqual(self.f.world.season.name, "spring")
-
-    test_update_season_advanced.todo = "update_seasons can't handle skipping the start day"


### PR DESCRIPTION
I made update_season take an approach similar to how the /time command used to work. I also modified the time command to use world.season now. This time there are tests.
