### PR TITLE
Cleaner error when failing on plugin importing

### DIFF
--- a/bravo/plugin.py
+++ b/bravo/plugin.py
@@ -249,7 +249,7 @@ def retrieve_named_plugins(interface, names, parameters=None):
         return [d[name] for name in names]
     except KeyError, e:
         raise PluginException("Couldn't find plugin %s for interface %s!" %
-            (e.args[0], interface))
+            (e.args[0], interface.__name__))
 
 def retrieve_sorted_plugins(interface, names, parameters=None):
     """

--- a/bravo/plugins/recipes.py
+++ b/bravo/plugins/recipes.py
@@ -588,6 +588,22 @@ class Fence(Recipe):
     )
     provides = (blocks["fence"].key, 2)
 
+class Bed(Recipe):
+
+    name = "bed"
+
+    dimensions = (3, 2)
+
+    recipe =(
+        (blocks["wool"].key, 1),
+        (blocks["wool"].key, 1),
+        (blocks["wool"].key, 1),
+        (blocks["wood"].key, 1),
+        (blocks["wood"].key, 1),
+        (blocks["wood"].key, 1),
+    )
+    provides = (blocks["bed"].key, 1)
+
 #--Recipies--
 
 #Basics
@@ -737,3 +753,4 @@ ladder = Ladder()
 papers = ThreeByOne(blocks["sugar-cane"], items["paper"], 3, "paper")
 book = Book()
 fence = Fence()
+bed = Bed()


### PR DESCRIPTION
plugin: cleaner exception output. Uses interface.**name** instead of just interface.
