### PR TITLE
Fix issue #320: End of stream error after closing inventory

### DIFF
--- a/bravo/protocols/beta.py
+++ b/bravo/protocols/beta.py
@@ -949,6 +949,11 @@ class BravoProtocol(BetaServerProtocol):
         self.factory.broadcast_for_others(packet, self)
 
     def wclose(self, container):
+        if container.wid == 0:
+            # notchian clients send a close window message with window id 0 to close
+            # their inventory even though there is never an Open Window message for inventory.
+            return
+
         top = self.windows.pop()
 
         # If the requested WID is on top of the stack, go ahead and close the
@@ -970,9 +975,6 @@ class BravoProtocol(BetaServerProtocol):
             sync_inventories(i, self.player.inventory)
             # All done!
             return
-        elif container.wid == 0:
-            # XXX Why does this happen? What should we do?
-            pass
         else:
             log.msg("Ignoring request to close non-current window %d" %
                 container.wid)


### PR DESCRIPTION
According to http://mc.kev009.com/Protocol#Close_window_.280x65.29 notchian clients send a close window message with window id 0 to close their inventory even though there is never an Open Window message for inventory.

We shall check `container.wid == 0` _before_ getting window from top of the stack.
