### PR TITLE
Fixed trees and grass automatons

### DIFF
--- a/bravo/plugins/automatons.py
+++ b/bravo/plugins/automatons.py
@@ -1,7 +1,7 @@
 from __future__ import division
 
 from itertools import product
-from random import randint, random
+from random import randint, random, sample
 
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
@@ -106,14 +106,17 @@ class Grass(object):
 
     def __init__(self):
         self.tracked = set()
-        self.loop = LoopingCall(self.process)
+        self.running = False
 
     def start(self):
-        if not self.loop.running:
+        if not self.running:
+            self.loop = LoopingCall(self.process)
             self.loop.start(self.step, now=False)
+            self.running = True
 
     def stop(self):
-        if self.loop.running:
+        if self.running:
+            self.running = False
             self.loop.stop()
 
     def reschedule(self):
@@ -127,7 +130,8 @@ class Grass(object):
 
         # Effectively stop tracking this block. We'll add it back in if we're
         # not finished with it.
-        coords = self.tracked.pop()
+        coords = sample(self.tracked,1)[0]
+        self.tracked.discard(coords)
 
         # Try to do our neighbor lookups. If it can't happen, don't worry
         # about it; we can get to it later. Grass isn't exactly a

--- a/bravo/plugins/physics.py
+++ b/bravo/plugins/physics.py
@@ -38,14 +38,17 @@ class Fluid(object):
         self.tracked = set()
         self.new = set()
 
-        self.loop = LoopingCall(self.process)
+        self.running = False
 
     def start(self):
-        if not self.loop.running:
+        if not self.running:
+            self.loop = LoopingCall(self.process)
             self.loop.start(self.step)
+            self.running = True
 
     def stop(self):
-        if self.loop.running:
+        if self.running:
+            self.running = False
             self.loop.stop()
 
     def schedule(self):

--- a/bravo/protocols/beta.py
+++ b/bravo/protocols/beta.py
@@ -915,7 +915,7 @@ class BravoProtocol(BetaServerProtocol):
         # Feed automatons.
         for automaton in self.factory.automatons:
             if newblock in automaton.blocks:
-                automaton.feed((builddata.x, builddata.y, builddata.z))
+                automaton.feed(adjust_coords_for_face((builddata.x, builddata.y, builddata.z), builddata.face))
 
         # Re-send inventory.
         # XXX this could be optimized if/when inventories track damage.

--- a/bravo/world.py
+++ b/bravo/world.py
@@ -325,7 +325,7 @@ class World(object):
         if chunk.populated:
             self.chunk_cache[x, z] = chunk
             self.postprocess_chunk(chunk)
-            #self.factory.scan_chunk(chunk)
+            self.factory.scan_chunk(chunk)
             returnValue(chunk)
 
         if self.async:
@@ -369,7 +369,7 @@ class World(object):
         # This one is for our return value.
         retval = pe.deferred()
         # This one is for scanning the chunk for automatons.
-        #pe.deferred().addCallback(self.factory.scan_chunk)
+        pe.deferred().addCallback(self.factory.scan_chunk)
         self._pending_chunks[x, z] = pe
 
         def pp(chunk):


### PR DESCRIPTION
In the Trees automaton, saplings would grow into trees even after they were removed from the ground (i.e. trees would grow from thin air), due to there not being a check for the block still being a sapling.

In the code to feed newly created blocks to automatons, they were given the coordinates of the block clicked on, instead of the block which was created.

There was a bug in the IDigHook implementation of Grass. Two objects of the class Grass are created: one for IAutomaton, and one for IDigHook. I think the implementation was assuming they were the same object, which I believe they are not.
