### PR TITLE
Add empty shooting handler to prevent client disconnect

### DIFF
--- a/bravo/beta/packets.py
+++ b/bravo/beta/packets.py
@@ -232,6 +232,7 @@ packets = {
             stopped=2,
             broken=3,
             dropped=4,
+            shooting=5,
         ),
         SBInt32("x"),
         UBInt8("y"),

--- a/bravo/beta/protocol.py
+++ b/bravo/beta/protocol.py
@@ -838,6 +838,10 @@ class BravoProtocol(BetaServerProtocol):
                         self.factory.broadcast_for_others(packet, self)
             return
 
+        if container.state == "shooting":
+            self.shoot_arrow()
+            return
+
         bigx, smallx, bigz, smallz = split_coords(container.x, container.z)
         coords = smallx, container.y, smallz
 
@@ -1093,6 +1097,12 @@ class BravoProtocol(BetaServerProtocol):
                     secondary=container.damage
                 )
                 self.factory.broadcast_for_others(packet, self)
+
+    def shoot_arrow(self):
+        # TODO 1. Create arrow entity:          arrow = Arrow(self.factory, self.player)
+        #      2. Register within the factory:  self.factory.register_entity(arrow)
+        #      3. Run it:                       arrow.run()
+        pass
 
     def sign(self, container):
         bigx, smallx, bigz, smallz = split_coords(container.x, container.z)


### PR DESCRIPTION
Shooting cause client disconnect. The commit adds empty arrow shooting handler to prevent this.
The code for Arrow entity is not ready yet so it is not included into the commit. 
