### PR TITLE
Guarantee that blocks are destroyed before dig hooks are called.

### DIFF
--- a/bravo/beta/protocol.py
+++ b/bravo/beta/protocol.py
@@ -966,12 +966,12 @@ class BravoProtocol(BetaServerProtocol):
 
         x, y, z = coords
 
+        if block.breakable:
+            chunk.destroy(coords)
+
         l = []
         for hook in self.dig_hooks:
             l.append(maybeDeferred(hook.dig_hook, chunk, x, y, z, block))
-
-        if block.breakable:
-            chunk.destroy(coords)
 
         dl = DeferredList(l)
         dl.addCallback(lambda none: self.factory.flush_chunk(chunk))


### PR DESCRIPTION
This fixes incorrect fluid behavior where when you dig away one
block that is adjacent to a spring, the water does not spread
because the automaton does not know that the newly dug area is
now empty.
